### PR TITLE
Feature/main 메인화면 구현

### DIFF
--- a/apis/controllers/index.js
+++ b/apis/controllers/index.js
@@ -1,5 +1,7 @@
 const userController = require("./userController");
+const mainController = require("./mainController");
 
 module.exports = {
   userController,
+  mainController,  
 };

--- a/apis/controllers/mainController.js
+++ b/apis/controllers/mainController.js
@@ -1,0 +1,57 @@
+const { mainService } = require("../services");
+const { catchAsync } = require("../../utils/error");
+
+const getMainPage = catchAsync(async (req, res, next) => {
+  const { id, query, regInterest } = req;
+  let search = (age = gender = interests = limit = offset = "");
+
+  if (query.search) {
+    search = query.search;
+  }
+  if (query.age) {
+    age = query.age;
+  }
+  if (query.gender && typeof query.gender != "object") {
+    gender = `"${query.gender}"`;
+  }
+  if (query.interests && typeof query.interests == "object") {
+    interests = [];
+    let interestsArray = query.interests;
+    for (i in interestsArray) {
+      interests.push(`"${interestsArray[i]}"`);
+    }
+  } else if (query.interests && typeof query.interests != "object") {
+    interests = `"${query.interests}"`;
+  }
+  if (query.limit) {
+    limit = query.limit;
+  }
+  if (query.offset) {
+    offset = query.offset;
+  }
+
+  const result = await mainService.getMainPage(
+    id,
+    search,
+    age,
+    gender,
+    interests,
+    limit,
+    offset,
+    regInterest
+  );
+
+  return res.status(200).json(result);
+});
+
+const createInterest = catchAsync(async (req, res, next) => {
+  const { id, body } = req;
+  const { interests } = body;
+  let result = await mainService.createInterest(id, interests);
+  return res.status(201).json(result);
+});
+
+module.exports = {
+  getMainPage,
+  createInterest,
+};

--- a/apis/models/index.js
+++ b/apis/models/index.js
@@ -1,7 +1,9 @@
 const userDao = require("./userDao");
+const mainDao = require("./mainDao");
 const database = require("./dataSource");
 
 module.exports = {
   userDao,
+  mainDao,
   database,
 };

--- a/apis/models/mainDao.js
+++ b/apis/models/mainDao.js
@@ -1,0 +1,109 @@
+const database = require("./dataSource");
+
+const getMainPage = async (
+  id,
+  search,
+  age,
+  gender,
+  interests,
+  limit,
+  offset,
+  regInterest
+) => {
+  let filter = (orderBy = pagenation = ``);
+  age ? (filter += ` AND u.age IN (${age})`) : ``;
+  gender ? (filter += ` AND u.gender IN (${gender})`) : ``;
+  interests ? (filter += ` AND i.interest IN (${interests})`) : ``;
+  regInterest
+    ? (orderBy += ` ORDER BY FIELD (i.id,${[
+        regInterest,
+      ]}) DESC, p.created_at DESC`)
+    : ``;
+  limit ? (pagenation += ` LIMIT ${limit}`) : ``;
+  limit && offset ? (pagenation += ` OFFSET ${offset * limit}`) : ``;
+
+  return await database.query(
+    `SELECT DISTINCT
+    p.id AS pinId, 
+    group_concat(i.interest) AS interest, 
+    u.username, 
+    u.profile_image AS profileImage, 
+    p.title,
+    p.content,
+    p.pin_image AS pinImage 
+    FROM users u 
+    INNER JOIN pins p on u.id = p.user_id 
+    INNER JOIN pin_interests pi on p.id = pi.pin_id 
+    INNER JOIN interests i on i.id = pi.interest_id
+    WHERE p.title LIKE ("%"?"%")
+    ${filter} 
+    OR u.username LIKE ("%"?"%")
+    ${filter} 
+    OR p.content LIKE ("%"?"%")
+    ${filter}
+    OR i.interest LIKE ("%"?"%")
+    ${filter}
+    GROUP BY p.id
+    ${orderBy}
+    ${pagenation}
+      `,
+    [search, search, search, search]
+  );
+};
+
+const getUserById = async (id) => {
+  return await database.query(
+    `SELECT 
+      id,
+      username,
+      profile_image
+    FROM users
+    WHERE id = ?  
+    `,
+    [id]
+  );
+};
+
+const getUserBoardById = async (id) => {
+  return await database.query(
+    `SELECT 
+    b.id,
+    b.name 
+    FROM boards b
+    WHERE b.user_id = ?
+    `,
+    [id]
+  );
+};
+
+const createInterest = async (id, interests) => {
+  let [convertInterest] = await database.query(
+    ` SELECT 
+    GROUP_CONCAT(i.id) AS interests_id 
+    FROM interests i    
+    WHERE i.interest 
+    IN (?)
+    `,
+    [interests]
+  );
+  replaceDot = convertInterest.interests_id.replace(/,/g, "");
+  let bulkInsert = [];
+  for (i in replaceDot) {
+    bulkInsert.push([+id, +replaceDot[i]]);
+  }
+
+  return await database.query(
+    `INSERT INTO user_interests
+  (user_id,interest_id)
+  VALUES ?
+      `,
+    [bulkInsert]
+  );
+};
+
+module.exports = {
+  getMainPage,
+  createInterest,
+  getUserById,
+  getUserBoardById,
+};

--- a/apis/models/userDao.js
+++ b/apis/models/userDao.js
@@ -37,7 +37,8 @@ const createUser = async (
 const getInterest = async () => {
   return await database.query(
     `SELECT
-        *
+        id,
+        interest
         FROM interests`
   );
 };

--- a/apis/routes/index.js
+++ b/apis/routes/index.js
@@ -2,7 +2,9 @@ const express = require("express");
 const router = express.Router();
 
 const userRouter = require("./userRouter");
+const mainRouter = require("./mainRouter");
 
 router.use("/user", userRouter);
+router.use("/main", mainRouter);
 
 module.exports = router;

--- a/apis/routes/mainRouter.js
+++ b/apis/routes/mainRouter.js
@@ -1,0 +1,11 @@
+const router = require("express").Router();
+
+const { mainController } = require("../controllers");
+const { loginRequired } = require("../../utils/auth");
+const { countInterests } = require("../../utils/interestsChecker")
+
+router.route("/").get(loginRequired,countInterests,mainController.getMainPage);
+router.route("/interest").post(loginRequired,mainController.createInterest)
+
+
+module.exports = router;

--- a/apis/services/index.js
+++ b/apis/services/index.js
@@ -1,5 +1,7 @@
 const userService = require("./userService");
+const mainService = require("./mainService");
 
 module.exports = {
   userService,
+  mainService,
 };

--- a/apis/services/mainService.js
+++ b/apis/services/mainService.js
@@ -1,0 +1,38 @@
+const { mainDao } = require("../models");
+
+const getMainPage = async (
+  id,
+  search,
+  age,
+  gender,
+  interests,
+  limit,
+  offset,
+  regInterest
+) => {
+  const main = await mainDao.getMainPage(
+    id,
+    search,
+    age,
+    gender,
+    interests,
+    limit,
+    offset,
+    regInterest
+  );
+
+  const user = await mainDao.getUserById(id);
+  const board = await mainDao.getUserBoardById(id);
+  let result = { users: user, boards: board, pins: main };
+
+  return result;
+};
+
+const createInterest = async (id, interests) => {
+  return await mainDao.createInterest(id, interests);
+};
+
+module.exports = {
+  getMainPage,
+  createInterest,
+};

--- a/utils/interestsChecker.js
+++ b/utils/interestsChecker.js
@@ -1,0 +1,29 @@
+const database = require("../apis/models/dataSource");
+
+const countInterests = async (req, res, next) => {
+  let { id } = req;
+  const userInterests = await database.query(
+    `
+    SELECT 
+    (interest_id) 
+    FROM user_interests 
+    WHERE user_id= ?
+        `,
+    [id]
+  );
+
+  let regInterest = [];
+  for (i in userInterests) {
+    regInterest.push(userInterests[i].interest_id);
+  }
+  if (userInterests.length >= 3) {
+    req.regInterest = regInterest;
+    return next();
+  } else {
+    const error = new Error(`Choose 3 or more interests`);
+    error.statusCode = 403;
+    next(error);
+  }
+};
+
+module.exports = { countInterests };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인화면 구성 완료
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인 후 메인페이지 진입시 utils/interestCheckers 미들웨어를 통해 토큰의 유저가 관심사를 3개이상 가지고있는지 체크한뒤
 3개이상 조건을 미달할시 프론엔드측과 협의한 error를 throw하여 관심사 설정페이지로 진입하도록함 

2. 관심사설정페이지에서 프론트엔드측이 보낸 interest("강아지" 등) 을 interest_id로 변환 한 뒤 이를 배열로 만들어
  벌크 인서트를 통해 한 쿼리로 입력하도록함

3. 쿼리스트링이 없는상태로 메인화면에 진입시 (= 필터 및 검색어가 없는상태) 유저의 관심사를 우선으로 정렬, 2순위로 created_at을
  기준으로 정렬하여 전달

4. 쿼리스트링으로 지정한 검색어 및 필터가 있는 경우 DAO에서 이를 조합하여 쿼리스트링의 조건에 맞는 데이터를 출력하도록함

5. 추가로 main데이터를 전송할때, 프론트측의 요청으로 유저의 프로필과 보드정보를 결과값에 넣어 전송함

<br />


<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
